### PR TITLE
add pagination to GET /articles endpoint

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -58,8 +58,6 @@ describe("/api", () => {
             .then(({ body: { articles } }) => {
               //check articles is an array
               expect(Array.isArray(articles)).toBe(true);
-              //check size of array with known number of article objects
-              expect(articles).toHaveLength(13);
 
               articles.forEach((article) => {
                 //check each article object contains the correct properties
@@ -134,6 +132,54 @@ describe("/api", () => {
             .expect(404)
             .then(({ body: { msg } }) => {
               expect(msg).toBe("No articles found for that query");
+            });
+        });
+      });
+      describe("GET /api/articles (pagination)", () => {
+        test("200; Responds with 10 articles by default and total_count property", () => {
+          return request(app)
+            .get("/api/articles")
+            .expect(200)
+            .then(({ body: { articles, total_count } }) => {
+              expect(articles.length).toBe(10);
+              expect(total_count).toBe(13);
+            });
+        });
+        let articlesPage1 = [];
+        test("200; Responds with 5 articles when passed a limit of 5", () => {
+          return request(app)
+            .get("/api/articles?limit=5")
+            .expect(200)
+            .then(({ body: { articles } }) => {
+              expect(articles.length).toBe(5);
+              articlesPage1 = [...articles];
+            });
+        });
+        let articlesPage2 = [];
+        test("200; Responds with a different page of 5 articles when passed p as 2", () => {
+          return request(app)
+            .get("/api/articles?limit=5&p=2")
+            .expect(200)
+            .then(({ body: { articles } }) => {
+              expect(articles.length).toBe(5);
+              articlesPage2 = [...articles];
+              expect(articlesPage1).not.toEqual(articlesPage2);
+            });
+        });
+        test("400; Resopnds with 'Invalid input when limit argument is invalid", () => {
+          return request(app)
+            .get("/api/articles?limit=banana")
+            .expect(400)
+            .then(({ body: { msg } }) => {
+              expect(msg).toBe("Invalid input");
+            });
+        });
+        test("400; Resopnds with 'Invalid input when p argument is invalid", () => {
+          return request(app)
+            .get("/api/articles?p=banana")
+            .expect(400)
+            .then(({ body: { msg } }) => {
+              expect(msg).toBe("Invalid input");
             });
         });
       });

--- a/src/controllers/articles.controller.js
+++ b/src/controllers/articles.controller.js
@@ -25,10 +25,16 @@ async function getArticleById(req, res, next) {
 }
 
 async function getArticles(req, res, next) {
-  const { sort_by, order, topic } = req.query;
+  const { sort_by, order, topic, limit, p } = req.query;
   try {
-    const articles = await selectArticles(sort_by, order, topic);
-    res.status(200).send({ articles });
+    const { articles, total_count } = await selectArticles(
+      sort_by,
+      order,
+      topic,
+      limit,
+      p
+    );
+    res.status(200).send({ articles, total_count });
   } catch (err) {
     next(err);
   }
@@ -112,7 +118,6 @@ async function postArticle(req, res, next) {
     );
     res.status(200).send({ newArticle });
   } catch (err) {
-    console.log(err);
     next(err);
   }
 }

--- a/src/models/articles.model.js
+++ b/src/models/articles.model.js
@@ -32,7 +32,13 @@ async function selectArticleById(articleId) {
   return rows[0];
 }
 
-async function selectArticles(sortBy = "created_at", order = "desc", topic) {
+async function selectArticles(
+  sortBy = "created_at",
+  order = "desc",
+  topic,
+  limit = 10,
+  p = 1
+) {
   const allowedSorts = [
     "author",
     "title",
@@ -45,7 +51,11 @@ async function selectArticles(sortBy = "created_at", order = "desc", topic) {
 
   if (
     !allowedSorts.includes(sortBy) ||
-    !allowedOrder.includes(order.toLowerCase())
+    !allowedOrder.includes(order.toLowerCase()) ||
+    isNaN(Number(limit)) ||
+    Number(limit) <= 0 ||
+    isNaN(Number(p)) ||
+    Number(p) <= 0
   ) {
     return Promise.reject({ status: 400, msg: "Invalid input" });
   }
@@ -88,8 +98,13 @@ async function selectArticles(sortBy = "created_at", order = "desc", topic) {
       msg: "No articles found for that query",
     });
   }
+  const startingIndex = Number(limit) * (Number(p) - 1);
+  const endingIndex = startingIndex + Number(limit);
 
-  return rows;
+  const paginatedRows = rows.slice(startingIndex, endingIndex);
+  const total_count = rows.length;
+
+  return { articles: paginatedRows, total_count };
 }
 
 async function selectCommentsByArticleId(articleId) {


### PR DESCRIPTION
Added pagination support to GET /api/articles with limit and p query parameters. The response also now includes a total_count field showing the total number of articles (respecting any filters). Both parameters are optional and defaults to showing 10 articles on page 1.