### PR TITLE
fix GET comments to return empty array instead of 404

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -508,12 +508,12 @@ describe("/api", () => {
               expect(msg).toBe("Invalid ID format");
             });
         });
-        test("404; Responds 'Comments not found' when article_id does not exist in the database", () => {
+        test("200; Responds 'with empty array when no comments are found in the database", () => {
           return request(app)
             .get("/api/articles/100/comments")
-            .expect(404)
-            .then(({ body: { msg } }) => {
-              expect(msg).toBe("Comments not found");
+            .expect(200)
+            .then(({ body: { comments } }) => {
+              expect(comments.length).toBe(0);
             });
         });
       });

--- a/src/controllers/articles.controller.js
+++ b/src/controllers/articles.controller.js
@@ -47,11 +47,6 @@ async function getCommentsByArticleId(req, res, next) {
   try {
     const comments = await selectCommentsByArticleId(article_id, limit, p);
 
-    //check if comments exists in database
-    if (comments.length === 0) {
-      return res.status(404).json({ msg: "Comments not found" });
-    }
-
     res.status(200).send({ comments });
   } catch (err) {
     next(err);


### PR DESCRIPTION
Removed the logic inf GET comments by article ID that would've returned 404 - not found if there were no comments for an article. This was bad design and would effect the front end. This will now return code 200 and an empty array.